### PR TITLE
Fix SONAME symlinks, and bump to 2.0.0 for ABI break.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,46 @@
+Changelog for librtas-2.0.0
+=======================================
+
+commit da9f484ab2429525101432d57176f376576c3dac
+Author: Adam Conrad <adconrad@0c3.net>
+Date:   Tue Apr 5 04:11:23 2016 -0600
+
+    Modernize and parameterize the RPM specfile slightly.
+    
+    Signed-off-by: Adam Conrad <adconrad@0c3.net>
+
+commit 9c1591cd262116290b5a651bc09192b6c34da9ce
+Author: Adam Conrad <adconrad@0c3.net>
+Date:   Tue Apr 5 01:38:33 2016 -0600
+
+    librtasevent: Fix build failure with -Wformat -Werror=format-security
+    
+    Signed-off-by: Adam Conrad <adconrad@0c3.net>
+
+commit 2644f9d269be8b852aa024f1364a5199aac268db
+Author: Adam Conrad <adconrad@0c3.net>
+Date:   Tue Apr 5 01:35:51 2016 -0600
+
+    librtas*/Makefile: install/uninstall static libs
+    
+    Signed-off-by: Adam Conrad <adconrad@0c3.net>
+
+commit f9bb81502e5fa3894caa1761292ec69580dc087e
+Author: Adam Conrad <adconrad@0c3.net>
+Date:   Tue Apr 5 01:30:41 2016 -0600
+
+    librtasevent: Generate static library.
+    
+    Signed-off-by: Adam Conrad <adconrad@0c3.net>
+
+commit 2b43240db6fe721288bf09a6f2c75743ae4f8855
+Author: Adam Conrad <adconrad@0c3.net>
+Date:   Fri Apr 1 08:34:16 2016 -0600
+
+    Use MAJOR_NO to define the SONAME symlinks, instead of hardcoding "1"
+    
+    Signed-off-by: Adam Conrad <adconrad@0c3.net>
+
 Changelog for librtas-1.4.1
 =======================================
 

--- a/librtas.spec.in
+++ b/librtas.spec.in
@@ -1,5 +1,6 @@
 %define name librtas
 %define version 1.4.1
+%define sover 1
 %define release 1
 Summary: Libraries to provide access to RTAS calls and RTAS events.
 Name: %{name}
@@ -9,7 +10,7 @@ License: GNU Lesser General Public License (LGPL)
 Source:  %{name}-%{version}.tar.gz
 Group: System Environment/Libraries
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
-
+ExclusiveArch: ppc ppc64 ppc64le
 
 %description
 The librtas shared library provides userspace with an interface
@@ -21,6 +22,23 @@ The librtasevent shared library provides users with a set of
 definitions and common routines useful in parsing and dumping
 the contents of RTAS events.
 
+%package devel
+Summary:  C header files for development with librtas
+Group:    Development/Libraries
+Requires: %{name}%{?_isa} = %{version}-%{release}
+
+%description devel
+The librtas-devel package contains the header files necessary for
+developing programs using librtas.
+
+%package static
+Summary:  Static verions of the librtas libraries
+Group:    Development/Libraries
+
+%description static
+The librtas-static package contains the static libraries which
+correspond to the librtas and librtas-devel packages.
+
 %prep
 %setup -q
 
@@ -31,32 +49,30 @@ the contents of RTAS events.
 %{__rm} -rf $RPM_BUILD_ROOT
 %{__make} install DESTDIR=$RPM_BUILD_ROOT
 
+%post
+ldconfig
+
+%postun
+ldconfig
 
 %files
 %defattr(-, root, root)
 %{_docdir}/%{name}/COPYING.LESSER
 %{_docdir}/%{name}/README
-%{_includedir}/librtas.h
+%{_libdir}/librtas.so.%{sover}
 %{_libdir}/librtas.so.%{version}
+%{_libdir}/librtasevent.so.%{sover}
+%{_libdir}/librtasevent.so.%{version}
+
+%files devel
 %{_libdir}/librtas.so
 %{_libdir}/librtasevent.so
-%{_libdir}/librtasevent.so.1
-%{_libdir}/librtasevent.so.%{version}
+%{_includedir}/librtas.h
 %{_includedir}/librtasevent.h
 %{_includedir}/librtasevent_v4.h
 %{_includedir}/librtasevent_v6.h
 
-%post
-# Post-install script -------------------------------------------------
-ln -sf %{_libdir}/librtas.so.%{version} %{_libdir}/librtas.so
-ln -sf %{_libdir}/librtas.so.%{version} %{_libdir}/librtas.so.1
-ln -sf %{_libdir}/librtasevent.so.%{version} %{_libdir}/librtasevent.so
-ldconfig
+%files static
+%{_libdir}/librtas.a
+%{_libdir}/librtasevent.a
 
-%postun
-# Post-uninstall script -----------------------------------------------
-if [ "$1" = "0" ] ; then        # last uninstall
-    rm -f %{_libdir}/librtas.so
-    rm -f %{_libdir}/librtasevent.so
-fi
-ldconfig

--- a/librtas.spec.in
+++ b/librtas.spec.in
@@ -1,6 +1,6 @@
 %define name librtas
-%define version 1.4.1
-%define sover 1
+%define version 2.0.0
+%define sover 2
 %define release 1
 Summary: Libraries to provide access to RTAS calls and RTAS events.
 Name: %{name}

--- a/librtas_src/Makefile
+++ b/librtas_src/Makefile
@@ -45,13 +45,13 @@ install:
 	@$(call install_lib,$(LIBRTAS),$(DESTDIR))
 	@$(call install_inc,$(HEADERS),$(DESTDIR))
 	@ln -sf $(LIBRTAS) $(DESTDIR)/$(LIB_DIR)$(call is_lib64,$(LIBRTAS))/$(LIBRTAS_SONAME)
-	@ln -sf $(LIBRTAS) $(DESTDIR)/$(LIB_DIR)$(call is_lib64,$(LIBRTAS))/$(LIBRTAS_SONAME).1
+	@ln -sf $(LIBRTAS) $(DESTDIR)/$(LIB_DIR)$(call is_lib64,$(LIBRTAS))/$(LIBRTAS_SONAME).$(MAJOR_NO)
 
 uninstall:
 	@$(call uninstall_lib,$(LIBRTAS),$(DESTDIR))
 	@$(call uninstall_inc,$(HEADERS),$(DESTDIR))
 	@rm -f $(DESTDIR)/$(LIB_DIR)$(call is_lib64,$(LIBRTAS))/$(LIBRTAS_SONAME)
-	@rm -f $(DESTDIR)/$(LIB_DIR)$(call is_lib64,$(LIBRTAS))/$(LIBRTAS_SONAME).1
+	@rm -f $(DESTDIR)/$(LIB_DIR)$(call is_lib64,$(LIBRTAS))/$(LIBRTAS_SONAME).$(MAJOR_NO)
 
 clean:
 	@echo "Cleaning up $(WORK_DIR) files..."

--- a/librtas_src/Makefile
+++ b/librtas_src/Makefile
@@ -43,12 +43,14 @@ librtas_static: $(LIBRTAS_OBJS) $(HEADERS)
 
 install:
 	@$(call install_lib,$(LIBRTAS),$(DESTDIR))
+	@$(call install_lib,$(LIBRTAS_STATIC),$(DESTDIR))
 	@$(call install_inc,$(HEADERS),$(DESTDIR))
 	@ln -sf $(LIBRTAS) $(DESTDIR)/$(LIB_DIR)$(call is_lib64,$(LIBRTAS))/$(LIBRTAS_SONAME)
 	@ln -sf $(LIBRTAS) $(DESTDIR)/$(LIB_DIR)$(call is_lib64,$(LIBRTAS))/$(LIBRTAS_SONAME).$(MAJOR_NO)
 
 uninstall:
 	@$(call uninstall_lib,$(LIBRTAS),$(DESTDIR))
+	@$(call uninstall_lib,$(LIBRTAS_STATIC),$(DESTDIR))
 	@$(call uninstall_inc,$(HEADERS),$(DESTDIR))
 	@rm -f $(DESTDIR)/$(LIB_DIR)$(call is_lib64,$(LIBRTAS))/$(LIBRTAS_SONAME)
 	@rm -f $(DESTDIR)/$(LIB_DIR)$(call is_lib64,$(LIBRTAS))/$(LIBRTAS_SONAME).$(MAJOR_NO)

--- a/librtasevent_src/Makefile
+++ b/librtasevent_src/Makefile
@@ -45,12 +45,14 @@ libre_static: $(LIBRE_OBJS) $(HEADERS)
 
 install:
 	@$(call install_lib,$(LIBRE),$(DESTDIR))
+	@$(call install_lib,$(LIBRE_STATIC),$(DESTDIR))
 	@$(call install_inc,$(LIBRE_HDRS),$(DESTDIR))
 	@ln -sf $(LIBRE) $(DESTDIR)/$(LIB_DIR)$(call is_lib64,$(LIBRE))/$(LIBRE_SONAME)
 	@ln -sf $(LIBRE) $(DESTDIR)/$(LIB_DIR)$(call is_lib64,$(LIBRE))/$(LIBRE_SONAME).$(MAJOR_NO)
 
 uninstall:
 	@$(call uninstall_lib,$(LIBRE),$(DESTDIR))
+	@$(call uninstall_lib,$(LIBRE_STATIC),$(DESTDIR))
 	@$(call uninstall_inc,$(LIBRE_HDRS),$(DESTDIR))
 	@rm -f $(DESTDIR)/$(LIB_DIR)$(call is_lib64,$(LIBRE))/$(LIBRE_SONAME)
 	@rm -f $(DESTDIR)/$(LIB_DIR)$(call is_lib64,$(LIBRE))/$(LIBRE_SONAME).$(MAJOR_NO)

--- a/librtasevent_src/Makefile
+++ b/librtasevent_src/Makefile
@@ -20,6 +20,7 @@
 include ../rules.mk
 
 LIBRE_SONAME = librtasevent.so
+LIBRE_STATIC = librtasevent.a
 LIBRE = $(LIBRE_SONAME).$(VERSION)
 
 LIBRE_OBJS = get_rtas_event.o print_rtas_event.o rtas_cpu.o rtas_dump.o	\
@@ -32,9 +33,15 @@ HEADERS = $(LIBRE_HDRS) rtas_event.h
 CFLAGS += -fPIC -DPIC -I.
 LDFLAGS += -shared -Wl,-soname -Wl,$(LIBRE_SONAME).$(MAJOR_NO)
 
-all: $(LIBRE_OBJS) $(HEADERS)
+all: libre_shared libre_static
+
+libre_shared: $(LIBRE_OBJS) $(HEADERS)
 	@echo "LD librtasevent_src/$(LIBRE)..."
 	@$(CC) $(LIBRE_OBJS) $(LDFLAGS) -o $(LIBRE)
+
+libre_static: $(LIBRE_OBJS) $(HEADERS)
+	@echo "AR $(LIBRE_STATIC)..."
+	@ar rcs $(LIBRE_STATIC) $(LIBRE_OBJS)
 
 install:
 	@$(call install_lib,$(LIBRE),$(DESTDIR))
@@ -50,5 +57,5 @@ uninstall:
 
 clean:
 	@echo "Cleaning up $(WORK_DIR) files..."
-	@rm -f $(LIBRE_OBJS) $(LIBRE_SONAME) $(LIBRE)
+	@rm -f $(LIBRE_OBJS) $(LIBRE_SONAME) $(LIBRE) $(LIBRE_STATIC)
 

--- a/librtasevent_src/Makefile
+++ b/librtasevent_src/Makefile
@@ -40,13 +40,13 @@ install:
 	@$(call install_lib,$(LIBRE),$(DESTDIR))
 	@$(call install_inc,$(LIBRE_HDRS),$(DESTDIR))
 	@ln -sf $(LIBRE) $(DESTDIR)/$(LIB_DIR)$(call is_lib64,$(LIBRE))/$(LIBRE_SONAME)
-	@ln -sf $(LIBRE) $(DESTDIR)/$(LIB_DIR)$(call is_lib64,$(LIBRE))/$(LIBRE_SONAME).1
+	@ln -sf $(LIBRE) $(DESTDIR)/$(LIB_DIR)$(call is_lib64,$(LIBRE))/$(LIBRE_SONAME).$(MAJOR_NO)
 
 uninstall:
 	@$(call uninstall_lib,$(LIBRE),$(DESTDIR))
 	@$(call uninstall_inc,$(LIBRE_HDRS),$(DESTDIR))
 	@rm -f $(DESTDIR)/$(LIB_DIR)$(call is_lib64,$(LIBRE))/$(LIBRE_SONAME)
-	@rm -f $(DESTDIR)/$(LIB_DIR)$(call is_lib64,$(LIBRE))/$(LIBRE_SONAME).1
+	@rm -f $(DESTDIR)/$(LIB_DIR)$(call is_lib64,$(LIBRE))/$(LIBRE_SONAME).$(MAJOR_NO)
 
 clean:
 	@echo "Cleaning up $(WORK_DIR) files..."

--- a/librtasevent_src/print_rtas_event.c
+++ b/librtasevent_src/print_rtas_event.c
@@ -343,7 +343,7 @@ rtas_print(char *fmt, ...)
 
             if (newline != NULL) {
                 prnt_len = newline - &tmpbuf[offset] + 1;
-                snprintf(buf + buf_offset, prnt_len, &tmpbuf[offset]);
+                snprintf(buf + buf_offset, prnt_len, "%s", &tmpbuf[offset]);
                 buf_offset = strlen(buf);
                 buf_offset += snprintf(buf + buf_offset,
 				       sizeof(buf) - buf_offset, "\n");
@@ -363,7 +363,7 @@ rtas_print(char *fmt, ...)
             }
 
             /* print up to the last brkpt */
-            snprintf(buf + buf_offset, prnt_len, &tmpbuf[offset]);
+            snprintf(buf + buf_offset, prnt_len, "%s", &tmpbuf[offset]);
             buf_offset = strlen(buf);
             buf_offset += snprintf(buf + buf_offset, sizeof(buf) - buf_offset,
 				   "\n");
@@ -374,10 +374,10 @@ rtas_print(char *fmt, ...)
     } 
 
     prnt_len = snprintf(buf + buf_offset, sizeof(buf) - buf_offset,
-			&tmpbuf[offset]);
+			"%s", &tmpbuf[offset]);
     line_offset += prnt_len;
 
-    return fprintf(ostream, buf);
+    return fprintf(ostream, "%s", buf);
 }
 
 /** 


### PR DESCRIPTION
In 1.4.0, the ABI of librtas.so.1 was broken pretty spectacularly (a large number of symbols were dropped, as can be seen in this diff):

```
--- librtas-1.3.13/debian/librtas1.symbols	2012-06-25 10:15:30.000000000 -0600
+++ librtas-1.4.1/debian/librtas2.symbols	2016-03-31 20:10:26.709394265 -0600
@@ -1,14 +1,6 @@
-librtas.so.1 librtas1 #MINVER#
- config@Base 1.3.6
- open_proc_rtas_file@Base 1.3.6
- pfs_cfg_connector@Base 1.3.6
- pfs_get_power@Base 1.3.6
- pfs_get_sensor@Base 1.3.6
- pfs_get_sysparm@Base 1.3.6
- pfs_set_indicator@Base 1.3.6
- pfs_set_power@Base 1.3.6
- procfs_interface_exists@Base 1.3.6
- procfs_rtas_ops@Base 1.3.6
+librtas.so.2 librtas2 #MINVER#
+ dbg_lvl@Base 1.4.1
+ interface_exists@Base 1.4.1
  read_entire_file@Base 1.3.6
  rtas_activate_firmware@Base 1.3.6
  rtas_cfg_connector@Base 1.3.6
@@ -44,37 +36,4 @@
  rtas_token@Base 1.3.6
  rtas_update_nodes@Base 1.3.6
  rtas_update_properties@Base 1.3.6
- sc_activate_firmware@Base 1.3.6
- sc_cfg_connector@Base 1.3.6
- sc_delay_timeout@Base 1.3.6
- sc_display_char@Base 1.3.6
- sc_display_msg@Base 1.3.6
- sc_errinjct@Base 1.3.6
- sc_errinjct_close@Base 1.3.6
- sc_errinjct_open@Base 1.3.6
- sc_free_rmo_buffer@Base 1.3.6
- sc_get_config_addr_info2@Base 1.3.6
- sc_get_dynamic_sensor@Base 1.3.6
- sc_get_indices@Base 1.3.6
- sc_get_power_level@Base 1.3.6
- sc_get_rmo_buffer@Base 1.3.6
- sc_get_sensor@Base 1.3.6
- sc_get_sysparm@Base 1.3.6
- sc_get_time@Base 1.3.6
- sc_get_vpd@Base 1.3.6
- sc_interface_exists@Base 1.3.6
- sc_lpar_perftools@Base 1.3.6
- sc_platform_dump@Base 1.3.6
- sc_read_slot_reset@Base 1.3.6
- sc_scan_log_dump@Base 1.3.6
- sc_set_dynamic_indicator@Base 1.3.6
- sc_set_eeh_option@Base 1.3.6
- sc_set_indicator@Base 1.3.6
- sc_set_power_level@Base 1.3.6
- sc_set_poweron_time@Base 1.3.6
- sc_set_sysparm@Base 1.3.6
- sc_set_time@Base 1.3.6
- sc_suspend_me@Base 1.3.6
- sc_update_nodes@Base 1.3.6
- sc_update_properties@Base 1.3.6
- syscall_rtas_ops@Base 1.3.6
+ sanity_check@Base 1.4.1
```

As such, the SOVER should have been bumped from 1 to 2.

In theory, one should probably decouple the ABI of librtas and librtasevent (as the latter hasn't changed), but given how rarely they break, I can understand the appeal of keeping it simple by just tying the SOVER to the upstream version and calling it a day.

So, following the above theory that simple is best, so as to not further complicate the build system, this pull request replaces the instances of hardcoded SOVERs, and bumps the package version to 2.0.0 to account for the undeclared ABI break in 1.4.x.